### PR TITLE
Add for getting a player's equipped items

### DIFF
--- a/CommonLibF4/include/RE/Bethesda/Actor.h
+++ b/CommonLibF4/include/RE/Bethesda/Actor.h
@@ -1267,6 +1267,13 @@ namespace RE
 			return func(this, a_perk);
 		}
 
+		BGSObjectInstance* GetEquippedItem(BGSObjectInstance* a_result, BGSEquipIndex a_equipIndex)
+		{
+			using func_t = decltype(&Actor::GetEquippedItem);
+			static REL::Relocation<func_t> func{ REL::ID(2231089) };
+			return func(this, a_result, a_equipIndex);
+		}
+
 		int32_t RequestDetectionLevel(Actor* a_target, DETECTION_PRIORITY a_priority = DETECTION_PRIORITY::kNormal)
 		{
 			using func_t = decltype(&Actor::RequestDetectionLevel);


### PR DESCRIPTION
기존 라이브러리에 구현되지 않은 GetEquippedItem 함수 구현 추가

원본 git의 로깅이 더 편리했기 때문에 다른 git에서 함수를 가져왔습니다.
해당 함수는 https://github.com/libxse/commonlibf4 의 Actor.h 에서 가져온 함수입니다.